### PR TITLE
GROUNDWORK-1894-upgrade-pg-version: upgrade debian for grafana

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
 # Final container
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 ARG GF_UID="472"
 ARG GF_GID="472"


### PR DESCRIPTION
Upgrade the debian release used in building the grafana image, from debian:stretch-slim to debian:bullseye-slim.  This is needed so we can use a PostgreSQL client of at least Pg10 to access the Pg14 we will be upgrading our "pg" container to run as.