### PR TITLE
Revert "GROUNDWORK-1894-upgrade-pg-version: upgrade debian for grafana"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
 # Final container
-FROM debian:bullseye-slim
+FROM debian:stretch-slim
 
 ARG GF_UID="472"
 ARG GF_GID="472"


### PR DESCRIPTION
Reverts gwos/grafana#13

Merging to the 8.3.0 branch was a mistake.  The changes should have gone into the GROUNDWORK branch instead.