### PR TITLE
GROUNDWORK-1894-use-bullseye-for-grafana:  switch debian release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
 # Final container
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 ARG GF_UID="472"
 ARG GF_GID="472"


### PR DESCRIPTION
Switch our grafana container from using debian:stretch-slim as the final basis for its image to debian:bullseye-slim so as to support an upgraded PostgreSQL release.