### PR TITLE
GROUNDWORK-3545: Grafana build is failing with error due to outdated chrome version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN sed -i '/export HOME/a \\nsource /check-groundwork-plugin.sh' /run.sh
 RUN apt update -qy \
     && apt install -qy wget \
     && wget --no-verbose -O /tmp/google-chrome-stable_amd64.deb \
-        https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.187-1_amd64.deb \
+        https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     && apt install -y /tmp/google-chrome-stable_amd64.deb \
     && apt install -qy fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
       --no-install-recommends \


### PR DESCRIPTION
Attempting to check whether the chome stable version is doing good.

The grafana build seems to be failing indicating the error below in Travis
===================================================
Preparing to unpack .../wget_1.20.3-1ubuntu2.1_amd64.deb ...
Unpacking wget (1.20.3-1ubuntu2.1) ...
Setting up wget (1.20.3-1ubuntu2.1) ...
https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.187-1_amd64.deb:
2024-09-05 06:36:38 ERROR 404: Not Found.
The command '/bin/sh -c apt update -qy     && apt install -qy wget     && wget --no-verbose -O /tmp/google-chrome-stable_amd64.deb         https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.187-1_amd64.deb     && apt install -y /tmp/google-chrome-stable_amd64.deb     && apt install -qy fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf       --no-install-recommends     && rm -rf /var/lib/apt/lists/* /tmp/google-chrome-stable_amd64.deb' returned a non-zero code: 8
travis.Makefile:50: recipe for target 'build' failed
make: *** [build] Error 8
The command "make --warn-undefined-variables -f travis.Makefile all" exited with 2.

![image](https://github.com/user-attachments/assets/fbed5d79-bdbf-4dbb-8284-5b5912fbfd98)
